### PR TITLE
Ported instructor docs to mdBook

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -50,6 +50,20 @@ RUN apt-get update && apt-get install -y apt-transport-https && apt-get update &
 RUN apt -y install default-jre default-jdk
 RUN echo "export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64" >> ~/.profile
 
+# Documentation
+## Rust for mdBook
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal
+## mdBook
+RUN ~/.cargo/bin/cargo install --git https://github.com/leanprover/mdBook mdbook
+## LeanInk
+RUN git clone https://github.com/leanprover/LeanInk.git
+WORKDIR /opt/LeanInk
+RUN /root/.elan/bin/lake build
+RUN echo "export PATH=/opt/LeanInk/build/bin:\$PATH" >> ~/.profile
+WORKDIR /opt
+## Alectryon
+RUN python3 -m pip install git+https://github.com/Kha/alectryon.git@typeid
+
 # TLA+
 # WORKDIR /opt 
 # RUN wget -q https://github.com/tlaplus/tlaplus/releases/download/v1.7.1/TLAToolbox-1.7.1-linux.gtk.amd64.deb && apt -y install ./TLAToolbox-1.7.1-linux.gtk.amd64.deb && rm ./TLAToolbox-1.7.1-linux.gtk.amd64.deb

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /build
 /lake-packages/*
+
+# mdBook output
+Instructor/DMT1/book/*
+Instructor/DMT1/src/*

--- a/Instructor/DMT1/book.toml
+++ b/Instructor/DMT1/book.toml
@@ -1,0 +1,6 @@
+[book]
+authors = ["Kevin Sullivan"]
+language = "en"
+multilingual = false
+src = "src"
+title = "DMT1"

--- a/Instructor/SUMMARY.md
+++ b/Instructor/SUMMARY.md
@@ -1,0 +1,6 @@
+# Summary
+
+[Introduction](./README.md)
+
+- [Resources](./Resources/README.md)
+- [Lectures 01 and 02](./Lectures/lecture_01_02.lean.md)

--- a/Instructor/build_book.sh
+++ b/Instructor/build_book.sh
@@ -1,0 +1,38 @@
+# This script must be placed in the same directory as the source files
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BOOK_PATH=$SCRIPT_DIR/DMT1
+SRC_PATH=$BOOK_PATH/src
+
+process_lean () {
+    local input_file_path=$1
+    local output_file_path=${SRC_PATH}/${input_file_path}.md
+    command="alectryon --frontend lean4+markup $input_file_path  --backend webpage -o $output_file_path"
+    echo $command
+    $command
+}
+
+process_other_files () {
+    local input_file_path=$1
+    local input_file_dir=$(dirname $input_file_path)
+    local output_file_dir=${SRC_PATH}/$input_file_dir
+    local output_file_path=$output_file_dir/$(basename $input_file_path)
+    mkdir -p $output_file_dir && cp $input_file_path $output_file_path
+}
+
+skip_items=("DMT1/" "build_book.sh")
+#mdbook build
+start_directory='.'
+find "$start_directory" -type f | grep -Ev "($(IFS="|"; echo "${skip_items[*]}"))" | while read -r file_path; do
+    # Use parameter expansion to extract the relative path
+    relative_path="${file_path#"$start_directory"/}"
+    filename=$(basename $relative_path)
+    extension="${filename##*.}"
+    if [ $extension = 'lean' ]; then 
+        process_lean $relative_path
+    else
+        process_other_files $relative_path
+    fi
+done
+
+cd $BOOK_PATH
+mdbook build


### PR DESCRIPTION
Added mdBook dependencies and a simple build script to generate a documentation book.

### Usage
* Lecture `lean`, markdown files, and any other resources (e.g. images) are placed in the `Instructor` directory as they usually are. 
* There is a new file `Instructor/SUMMARY.md` that contains the book outline. This file acts as the index of the book; only markdown files added to SUMMARY.md are compiled into the website. Paths inside the `SUMMARY.md` file should be relative to it. 
* When importing a `lean` file into the `SUMMARY.md` file, append `.md` to the file name. For example, to add the file `Instructor/Lectures/lecture_01_02.lean` to the `SUMMARY.md` file. You'd add it like this
    ```md
    - [Lectures 01 and 02](./Lectures/lecture_01_02.lean.md)
    ```
* To generate the documentation website, navigate to `Instructor` and run the `build_book.sh` script. This will generate the website inside the folder `Instructor/DMT1/book` file. 
* The name of the book and its authors can be changed inside the `Instructor/DMT1/book.toml` file.

### Detailed changes
- Added to the Dockerfile installation of Rust, mdbook, LeanInk, and Alectryon.
- Added a SUMMARY.md file to the Instructor folder, which is needed for an mdBook.
- Added the folder Instructor/DMT1 and the file `book.toml` in that directory. 
- Added the script Instructor/build_book.sh which uses the lean, markdown, and all other files in `Instructor` to generate an mdBook.

